### PR TITLE
Fix: Attempt to address multiple unit test failures

### DIFF
--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -1,6 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
-<phpunit backupGlobals="false"
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/9.6/phpunit.xsd"
+         backupGlobals="false"
          backupStaticAttributes="false"
          colors="true"
          convertErrorsToExceptions="true"

--- a/test/ArgoCD/Tests/Api/Organization/TeamsTest.php
+++ b/test/ArgoCD/Tests/Api/Organization/TeamsTest.php
@@ -2,7 +2,7 @@
 
 namespace ArgoCD\Tests\Api\Organization;
 
-use ArgoCD\Exception\MissingArgumentException;
+use ArgoCD\Exception\InvalidArgumentException;
 use ArgoCD\Tests\Api\TestCase;
 
 class TeamsTest extends TestCase
@@ -204,7 +204,7 @@ class TeamsTest extends TestCase
      */
     public function shouldNotCreateTeamWithoutName()
     {
-        $this->expectException(MissingArgumentException::class);
+        $this->expectException(InvalidArgumentException::class);
         $data = [];
 
         $api = $this->getApiMock();
@@ -270,7 +270,7 @@ class TeamsTest extends TestCase
      */
     public function shouldNotUpdateTeamWithoutName()
     {
-        $this->expectException(MissingArgumentException::class);
+        $this->expectException(InvalidArgumentException::class);
         $data = [];
 
         $api = $this->getApiMock();

--- a/test/ArgoCD/Tests/ClientTest.php
+++ b/test/ArgoCD/Tests/ClientTest.php
@@ -20,7 +20,7 @@ class ClientTest extends \PHPUnit\Framework\TestCase
      */
     public function shouldNotHaveToPassHttpClientToConstructor()
     {
-        $client = new Client();
+        $client = new Client('http://localhost');
 
         $this->assertInstanceOf(ClientInterface::class, $client->getHttpClient());
     }
@@ -33,74 +33,49 @@ class ClientTest extends \PHPUnit\Framework\TestCase
         $httpClientMock = $this->getMockBuilder(ClientInterface::class)
             ->getMock();
 
-        $client = Client::createWithHttpClient($httpClientMock);
+        $client = Client::createWithHttpClient($httpClientMock, 'http://localhost');
 
         $this->assertInstanceOf(ClientInterface::class, $client->getHttpClient());
     }
 
     /**
      * @test
-     *
-     * @dataProvider getAuthenticationFullData
      */
-    public function shouldAuthenticateUsingAllGivenParameters($login, $password, $method)
+    public function shouldSetBearerTokenAuthenticationPluginOnAuthenticate()
     {
+        $testToken = 'test_token';
+
         $builder = $this->getMockBuilder(Builder::class)
             ->setMethods(['addPlugin', 'removePlugin'])
-            ->disableOriginalConstructor()
+            ->disableOriginalConstructor() // Use disableOriginalConstructor if Builder has a complex constructor
             ->getMock();
-        $builder->expects($this->once())
-            ->method('addPlugin')
-            ->with($this->equalTo(new Authentication($login, $password, $method)));
+
+        // Expect removePlugin to be called to clear any existing auth
         $builder->expects($this->once())
             ->method('removePlugin')
-            ->with(Authentication::class);
+            ->with($this->equalTo(Authentication::class));
 
-        $client = $this->getMockBuilder(\ArgoCD\Client::class)
-            ->disableOriginalConstructor()
+        // Expect addPlugin to be called with the new Authentication plugin
+        $builder->expects($this->once())
+            ->method('addPlugin')
+            ->with($this->equalTo(new Authentication($testToken, AuthMethod::BEARER_TOKEN)));
+
+        $client = $this->getMockBuilder(Client::class)
+            ->setConstructorArgs(['http://localhost']) // Ensure constructor is called with necessary args
             ->setMethods(['getHttpClientBuilder'])
             ->getMock();
+
         $client->expects($this->any())
             ->method('getHttpClientBuilder')
             ->willReturn($builder);
 
-        $client->authenticate($login, $password, $method);
-    }
+        // Mock the SessionService and its create method if client->authenticate directly calls it
+        // For this refactoring, we assume authenticate directly configures the builder as per task
+        // If authenticate itself makes an API call to validate the token, that would need further mocking.
+        // Based on Client::authenticate method, it does try to make a call if password is not null.
+        // However, we are calling with only a token.
 
-    public function getAuthenticationFullData()
-    {
-        return [
-            ['token', null, AuthMethod::ACCESS_TOKEN],
-            ['client_id', 'client_secret', AuthMethod::CLIENT_ID],
-            ['token', null, AuthMethod::JWT],
-        ];
-    }
-
-    /**
-     * @test
-     */
-    public function shouldAuthenticateUsingGivenParameters()
-    {
-        $builder = $this->getMockBuilder(Builder::class)
-            ->setMethods(['addPlugin', 'removePlugin'])
-            ->getMock();
-        $builder->expects($this->once())
-            ->method('addPlugin')
-            ->with($this->equalTo(new Authentication('token', null, AuthMethod::ACCESS_TOKEN)));
-
-        $builder->expects($this->once())
-            ->method('removePlugin')
-            ->with(Authentication::class);
-
-        $client = $this->getMockBuilder(\ArgoCD\Client::class)
-            ->disableOriginalConstructor()
-            ->setMethods(['getHttpClientBuilder'])
-            ->getMock();
-        $client->expects($this->any())
-            ->method('getHttpClientBuilder')
-            ->willReturn($builder);
-
-        $client->authenticate('token', AuthMethod::ACCESS_TOKEN);
+        $client->authenticate($testToken);
     }
 
     /**
@@ -109,7 +84,7 @@ class ClientTest extends \PHPUnit\Framework\TestCase
     public function shouldThrowExceptionWhenAuthenticatingWithoutMethodSet()
     {
         $this->expectException(InvalidArgumentException::class);
-        $client = new Client();
+        $client = new Client('http://localhost');
 
         $client->authenticate('login', null, null);
     }
@@ -121,7 +96,7 @@ class ClientTest extends \PHPUnit\Framework\TestCase
      */
     public function shouldGetApiInstance($apiName, $class)
     {
-        $client = new Client();
+        $client = new Client('http://localhost');
 
         $this->assertInstanceOf($class, $client->api($apiName));
     }
@@ -133,7 +108,7 @@ class ClientTest extends \PHPUnit\Framework\TestCase
      */
     public function shouldGetMagicApiInstance($apiName, $class)
     {
-        $client = new Client();
+        $client = new Client('http://localhost');
 
         $this->assertInstanceOf($class, $client->$apiName());
     }
@@ -144,7 +119,19 @@ class ClientTest extends \PHPUnit\Framework\TestCase
     public function shouldNotGetApiInstance()
     {
         $this->expectException(InvalidArgumentException::class);
-        $client = new Client();
+        $client = new Client('http://localhost');
         $client->api('do_not_exist');
+    }
+
+    public function getApiClassesProvider()
+    {
+        return [
+            ['session', \ArgoCD\Api\SessionService::class],
+            ['sessionservice', \ArgoCD\Api\SessionService::class],
+            ['application', \ArgoCD\Api\ApplicationService::class],
+            ['applicationservice', \ArgoCD\Api\ApplicationService::class],
+            ['account', \ArgoCD\Api\AccountService::class],
+            ['accountservice', \ArgoCD\Api\AccountService::class],
+        ];
     }
 }

--- a/test/ArgoCD/Tests/Integration/TestCase.php
+++ b/test/ArgoCD/Tests/Integration/TestCase.php
@@ -22,7 +22,7 @@ class TestCase extends \PHPUnit\Framework\TestCase
     public function initClient()
     {
         // You have to specify authentication here to run full suite
-        $client = new Client();
+        $client = new Client('http://localhost');
 
         try {
             $client->api('current_user')->show();


### PR DESCRIPTION
This commit includes fixes for several issues identified in the PHPUnit test suite:

- Updated client instantiation in tests to provide a required server URL.
- Refactored authentication tests in ClientTest.php to align with the current bearer token authentication mechanism, removing references to obsolete AuthMethod constants.
- Added the missing getApiClassesProvider data provider method to ClientTest.php.
- Changed expected MissingArgumentException to InvalidArgumentException in TeamsTest.php.
- Installed php-curl extension and attempted to update phpunit.xml.dist schema.

Work is incomplete. A fatal error regarding incompatible method signatures between SessionService::delete() and AbstractApi::delete() was identified and needs to be resolved. The PHPUnit deprecated schema warning also persists.